### PR TITLE
リダイレクト処理実装

### DIFF
--- a/App.php
+++ b/App.php
@@ -60,7 +60,16 @@ class App
       $this->view->rend('Board.php', $threads);
     } elseif ($action[1] === 'post') {
       $user_name = $_POST['user_name'];
+      // user_nameが空の場合、固定値を指定
+      if (empty($user_name)) {
+        $user_name = '名無しさん';
+      }
       $body      = $_POST['body'];
+      if (empty($body)) {
+        header('Location: http://localhost:8002');
+        exit;
+      }
+
       $this->dbcon->postThread($user_name, $body);
       header('Location: http://localhost:8002');
     } else {

--- a/App.php
+++ b/App.php
@@ -62,6 +62,7 @@ class App
       $user_name = $_POST['user_name'];
       $body      = $_POST['body'];
       $this->dbcon->postThread($user_name, $body);
+      header('Location: http://localhost:8002');
     } else {
       // 404エラーページのレンダリング
       header('HTTP/1.0 404 Not Found');

--- a/Board.php
+++ b/Board.php
@@ -8,8 +8,14 @@
   <h1>2ch</h1>
   <div>
     <form action="http://localhost:8002/post" method="post">
-      <label for="post">投稿者</label><textarea id="text" name=user_name cols="20" rows="1" maxlength="20" placeholder="投稿者名"></textarea><br>
-      <textarea id="text" name="body" cols="50" rows="6" maxlength="255" placeholder="投稿内容"></textarea>
+      <div>
+        <label for="user_name">投稿者：</label><br>
+        <textarea id="text" name="user_name" cols="20" rows="1" maxlength="20" placeholder="投降者名"></textarea>
+      </div>
+      <div>
+        <label for="body">投稿内容：</label><br>
+        <textarea id="text" name="body" cols="50" rows="6" maxlength="255" placeholder="投稿内容"></textarea>
+      </div>
       <p><input type="submit" value="送信"></p>
     </form>
   </div>

--- a/Board.php
+++ b/Board.php
@@ -10,11 +10,11 @@
     <form action="http://localhost:8002/post" method="post">
       <div>
         <label for="user_name">投稿者：</label><br>
-        <textarea id="text" name="user_name" cols="20" rows="1" maxlength="20" placeholder="投降者名"></textarea>
+        <textarea id="text" name="user_name" cols="20" rows="1" maxlength="20" placeholder="名無しさん"></textarea>
       </div>
       <div>
         <label for="body">投稿内容：</label><br>
-        <textarea id="text" name="body" cols="50" rows="6" maxlength="255" placeholder="投稿内容"></textarea>
+        <textarea id="text" name="body" cols="50" rows="6" maxlength="255" placeholder="投稿内容（必須）"></textarea>
       </div>
       <p><input type="submit" value="送信"></p>
     </form>

--- a/Dbcon.php
+++ b/Dbcon.php
@@ -28,7 +28,6 @@ class Dbcon
       // $stmtの実行
       $stmt->execute();
 
-      echo '投稿が完了しました';
     // 失敗時の処理
     } catch (PDOException $e) {
       echo "接続失敗: " . $e->getMessage() . "\n";


### PR DESCRIPTION
# WHAT
リダイレクト機能実装
# WHY
投稿後に一覧ページに遷移させるため
また、投稿者名が空だった場合、固定値を設定
逆に投稿内容がからだった際はexitを用いて投稿を保存せず一覧ページへ遷移するように仕様変更